### PR TITLE
Update to apache poi 5.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.docu-tools'
-version = '1.0.4'
+version = '1.1.0'
 sourceCompatibility = 17
 targetCompatibility = 17
 
@@ -47,10 +47,12 @@ publishing {
     }
 }
 
+def apachePOIVersion = '5.0.0'
+
 dependencies {
-    implementation("org.apache.poi:poi:4.1.2")
-    implementation("org.apache.poi:poi-ooxml:4.1.2")
-    implementation("org.apache.poi:poi-ooxml-schemas:4.1.2")
+    implementation("org.apache.poi:poi:$apachePOIVersion")
+    implementation("org.apache.poi:poi-ooxml:$apachePOIVersion")
+    implementation("org.apache.poi:poi-ooxml-lite:$apachePOIVersion")
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.8.1')
     testImplementation("org.hamcrest:hamcrest:2.2")


### PR DESCRIPTION
Supersedes https://github.com/DDS-GmbH/poipath/pull/20 and https://github.com/DDS-GmbH/poipath/pull/21
Also increases version to `1.1.0`