### PR TITLE
Update CVSS threshold

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,8 +69,8 @@ test {
 
 dependencyCheck {
     format = 'ALL'
-    junitFailOnCVSS = 7.0
-    failBuildOnCVSS = 9.0
+    junitFailOnCVSS = 6.0
+    failBuildOnCVSS = 6.0
     suppressionFile = 'config/dependency-check/suppression.xml'
 }
 tasks.withType(Checkstyle) {


### PR DESCRIPTION
Up until now, a CVSS threshold of 9.0 was specified, which meant that it
practically never triggers. Especially with the introduction of dependabot
it is important to keep an eye on vulnerabilities.