### PR TITLE
Upgrade apache poi to 5.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.docutools'
-version = '1.1.4'
+version = '1.1.5'
 sourceCompatibility = 17
 targetCompatibility = 17
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ publishing {
     }
 }
 
-def apachePOIVersion = '5.0.0'
+def apachePOIVersion = '5.1.0'
 
 dependencies {
     implementation("org.apache.poi:poi:$apachePOIVersion")


### PR DESCRIPTION
Apache poi 5.0.0 included some vulnerable libraries.
5.1.0 should fix some, if not all, of those.