### PR TITLE
Do not run sonarcloud if triggered by dependabot

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,6 +84,7 @@ jobs:
   sonarcloud:
     name: sonarcloud
     runs-on: ubuntu-20.04
+    if: ${{ github.actor != 'dependabot[bot]' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
Since all sonarcloud checks triggered by dependabot fail, this job is now
disabled if the push is done by dependabot.